### PR TITLE
fix: complete next-intl setup with setRequestLocale, hasLocale valida…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A Next.js starter template pre-configured with shadcn/ui, Tailwind CSS v4, next-intl (i18n), Zustand (state management), and next-themes (dark mode). Designed for rapid project scaffolding.
 
-**Tech stack**: Next.js 15 · React 19 · TypeScript 5 · Tailwind CSS 4 · shadcn/ui · Zustand 5 · next-intl · next-themes
+**Tech stack**: Next.js 16 · React 19 · TypeScript 6 · Tailwind CSS 4 · shadcn/ui (Base UI) · Zustand 5 · next-intl · next-themes
 
 ## Commands
 
@@ -35,7 +35,7 @@ This ensures theme/state providers are available globally while i18n is scoped t
 - **Request handler**: `src/i18n/request.ts` — locale resolution
 - **Navigation**: `src/i18n/navigation.ts` — locale-aware `Link`, `redirect`, `useRouter`, `usePathname`
 - **Translations**: `messages/en.json`, `messages/zh.json`
-- **Middleware**: `src/middleware.ts` — automatic locale detection/redirect
+- **Middleware**: `src/proxy.ts` — automatic locale detection/redirect
 - **Next.js plugin**: `next.config.ts` uses `createNextIntlPlugin()`
 
 **Important**: Always use navigation utilities from `@/i18n/navigation` instead of `next/navigation`.
@@ -56,9 +56,9 @@ Vanilla store pattern for SSR compatibility:
 
 ### shadcn/ui
 
-- Style: `new-york` · Base color: `zinc` · CSS variables enabled
+- Style: `base-nova` · Base color: `neutral` · CSS variables enabled
 - Components: `src/components/ui/` (auto-installed via CLI)
-- Radix primitives via unified `radix-ui` package
+- Base UI primitives via `@base-ui/react` package
 - Config: `components.json`
 - Utilities: `cn()` from `@/lib/utils`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Next.js + shadcn/ui Template
 
-A modern, feature-rich template with **Next.js 15**, **shadcn/ui**, **Zustand**, **next-themes**, and **next-intl** internationalization. Perfect for kickstarting your next project with powerful built-in features.
+A modern, feature-rich template with **Next.js 16**, **shadcn/ui (Base UI)**, **Zustand**, **next-themes**, and **next-intl** internationalization. Perfect for kickstarting your next project with powerful built-in features.
 
 Built by **[LIKEDREAMWALKER](https://github.com/LikeDreamwalker)** with love ❤️
 
@@ -10,8 +10,8 @@ Check out the live demo: [nextjs-shadcn-template-alpha.vercel.app](https://nextj
 
 ## ✨ Features
 
-- 🎯 **[Next.js 15](https://nextjs.org)** - Latest React framework with App Router
-- 🎨 **[shadcn/ui](https://ui.shadcn.com)** - Beautiful and accessible UI components
+- 🎯 **[Next.js 16](https://nextjs.org)** - Latest React framework with App Router & Turbopack
+- 🎨 **[shadcn/ui](https://ui.shadcn.com)** - Beautiful and accessible UI components (Base UI)
 - 📦 **[Zustand](https://zustand-demo.pmnd.rs)** - Simple and scalable state management
 - 🌙 **[next-themes](https://github.com/pacocoursey/next-themes)** - Perfect dark mode support
 - 🌍 **[next-intl](https://next-intl-docs.vercel.app)** - Complete internationalization (English & Chinese)
@@ -24,19 +24,19 @@ Check out the live demo: [nextjs-shadcn-template-alpha.vercel.app](https://nextj
 
 | Technology   | Purpose              | Version |
 | ------------ | -------------------- | ------- |
-| Next.js      | React Framework      | 15.5.0  |
-| shadcn/ui    | UI Component Library | Latest  |
-| Zustand      | State Management     | 5.0.8   |
+| Next.js      | React Framework      | 16.2.3  |
+| shadcn/ui    | UI Component Library | Latest (Base UI) |
+| Zustand      | State Management     | 5.0.12   |
 | next-themes  | Theme Management     | 0.4.6   |
-| next-intl    | Internationalization | 4.3.4   |
-| TypeScript   | Type Safety          | 5.x     |
+| next-intl    | Internationalization | 4.9.0   |
+| TypeScript   | Type Safety          | 6.x     |
 | Tailwind CSS | Styling              | 4.x     |
 
 ## 🚦 Getting Started
 
 ### Prerequisites
 
-- Node.js 18.17 or later
+- Node.js 20.9 or later
 - pnpm (recommended) or npm/yarn
 
 ### Installation

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,14 +1,25 @@
-import { NextIntlClientProvider } from "next-intl";
-import { getMessages } from "next-intl/server";
+import { NextIntlClientProvider, hasLocale } from "next-intl";
+import { getMessages, setRequestLocale } from "next-intl/server";
+import { notFound } from "next/navigation";
+import { routing } from "@/i18n/routing";
 
-export default async function LocaleLayout({
-  children,
-  params,
-}: {
+type Props = {
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
-}) {
+};
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export default async function LocaleLayout({ children, params }: Props) {
   const { locale } = await params;
+
+  if (!hasLocale(routing.locales, locale)) {
+    notFound();
+  }
+
+  setRequestLocale(locale);
   const messages = await getMessages();
 
   return (

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,6 +1,15 @@
+import { setRequestLocale } from "next-intl/server";
 import { DemoCard } from "@/components/demo-card";
 
-export default async function HomePage() {
+export default async function HomePage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+
+  setRequestLocale(locale);
+
   return (
     <main>
       <DemoCard />


### PR DESCRIPTION
…tion, and generateStaticParams

- Add hasLocale() + notFound() in [locale]/layout.tsx for invalid locale fallback
- Add setRequestLocale(locale) in [locale]/layout.tsx and [locale]/page.tsx for static rendering
- Add generateStaticParams() for pre-rendering all locale routes at build time
- Update README: Next.js 15 -> 16, shadcn/ui Base UI, version table, Node.js requirement
- Update CLAUDE.md: tech stack, middleware reference, shadcn/ui section (base-nova, @base-ui/react)